### PR TITLE
ENV variable update

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,7 +23,7 @@ You can set your api_key globally and call class methods:
     Gibbon.api_key = "your_api_key"
     Gibbon.lists
 
-You can also set the environment variable 'MC_API_KEY' and Gibbon will use it when you create an instance:
+You can also set the environment variable 'MAILCHIMP_API_KEY' and Gibbon will use it when you create an instance:
 
     u = Gibbon.new
 

--- a/lib/gibbon.rb
+++ b/lib/gibbon.rb
@@ -11,7 +11,7 @@ class Gibbon
   attr_accessor :api_key, :timeout
 
   def initialize(api_key = nil, extra_params = {})
-    @api_key = api_key || ENV['MC_API_KEY'] || self.class.api_key
+    @api_key = api_key || ENV['MAILCHIMP_API_KEY'] || self.class.api_key
     @default_params = {:apikey => @api_key}.merge(extra_params)
   end
 


### PR DESCRIPTION
Hi I spoke with Federico about this. For the ENV var stuff to work with Heroku the variable key must be prefixed with the name of the addon. Currently the addon's name is "Mailchimp" so we need the ENV var to start with "MAILCHIMP" instead of "MC".
