### PR TITLE
Some responses not decoded properly

### DIFF
--- a/lib/gibbon.rb
+++ b/lib/gibbon.rb
@@ -39,7 +39,7 @@ protected
     begin
       response = ActiveSupport::JSON.decode(response.body)
     rescue
-      response = response.body
+      response = ActiveSupport::JSON.decode('['+response.body+']').first
     end
 
     if @throws_exceptions && response.is_a?(Hash) && response["error"]


### PR DESCRIPTION
in rails 3.1.3, ActiveSupport::JSON.decode does not correctly decode …

…strings like:

ActiveSupport::JSON.decode('"ahbfdnjs"')
ActiveSupport::JSON.decode('true')

This is a workaround that cajoles the library to decode it properly by wrapping it in []
