### PR TITLE
Make Gibbon more datacenter aware

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ gem "rdoc"
 
 group :development, :test do
   gem "shoulda", ">= 0"
-  gem "bundler", "~> 1.0.0"
-  gem "jeweler", "~> 1.5.1"
+  gem "bundler", "~> 1.0"
+  gem "jeweler", "~> 1.5"
   gem "rcov", ">= 0"
   gem "mocha", "> 0.9.11"
 

--- a/README.markdown
+++ b/README.markdown
@@ -35,6 +35,17 @@ separated formatting as you see in the "More Advanced Examples" section below.
 
 Check the API [documentation](http://apidocs.mailchimp.com/api/1.3/) for details.
 
+## Datacenter Aware
+
+OAuth 2 Strategy provides you with tokens along with datacenter information e.g. us1, us2
+
+    gb = Gibbon.new("your_api_key")
+    gb.datacenter = "us1"
+
+This will automatically append "us1" to your key when using internally. Alternatively you can also do:
+
+    gb = Gibbon.new("your_api_key-datacenter")
+
 ### Fetching Campaigns
 
 For example, to fetch your first 100 campaigns (page 0):

--- a/lib/gibbon.rb
+++ b/lib/gibbon.rb
@@ -7,7 +7,7 @@ class Gibbon
   format :plain
   default_timeout 30
 
-  attr_accessor :api_key, :timeout, :throws_exceptions
+  attr_accessor :api_key, :timeout, :throws_exceptions, :datacenter
 
   def initialize(api_key = nil, extra_params = {})
     @api_key = api_key || ENV['MC_API_KEY'] || ENV['MAILCHIMP_API_KEY'] || self.class.api_key
@@ -33,6 +33,7 @@ protected
   def call(method, params = {})
     api_url = base_api_url + method
     params = @default_params.merge(params)
+    params[:apikey] = "#{params[:apikey]}-#{datacenter}" if (datacenter && params[:apikey] !~ /-/)
     response = self.class.post(api_url, :body => CGI::escape(params.to_json), :timeout => @timeout)
 
     begin
@@ -57,7 +58,7 @@ protected
   end
 
   class << self
-    attr_accessor :api_key
+    attr_accessor :api_key, :datacenter
 
     def method_missing(sym, *args, &block)
       new(self.api_key).send(sym, *args, &block)
@@ -65,7 +66,7 @@ protected
   end
 
   def dc_from_api_key
-    (@api_key.nil? || @api_key.empty? || @api_key !~ /-/) ? '' : "#{@api_key.split("-").last}."
+    datacenter ? "#{datacenter}." : ((@api_key.nil? || @api_key.empty? || @api_key !~ /-/) ? '' : "#{@api_key.split("-").last}.")
   end
 end
 

--- a/test/test_gibbon.rb
+++ b/test/test_gibbon.rb
@@ -46,6 +46,13 @@ class TestGibbon < Test::Unit::TestCase
       @gibbon.timeout = timeout
       assert_equal(timeout, @gibbon.timeout)
     end
+    
+    should "set datacenter and get" do
+      @gibbon = Gibbon.new
+      datacenter = "us4"
+      @gibbon.datacenter = datacenter
+      assert_equal(datacenter, @gibbon.datacenter)
+    end
   end
 
   context "build api url" do
@@ -76,6 +83,22 @@ class TestGibbon < Test::Unit::TestCase
       @api_key = "TESTKEY-us1"
       @gibbon.api_key = @api_key
       expect_post("https://us1.api.mailchimp.com/1.3/?method=sayHello", {"apikey" => @api_key})
+      @gibbon.say_hello
+    end
+
+    should "handle datacenter" do
+      @api_key = "123"
+      @gibbon.api_key = @api_key
+      @gibbon.datacenter = "us4"
+      expect_post("https://us4.api.mailchimp.com/1.3/?method=sayHello", {"apikey" => "#{@api_key}-us4"})
+      @gibbon.say_hello
+    end
+
+    should "handle datacenter and api key with dc" do
+      @api_key = "123-us1"
+      @gibbon.api_key = @api_key
+      @gibbon.datacenter = "us4"
+      expect_post("https://us4.api.mailchimp.com/1.3/?method=sayHello", {"apikey" => @api_key})
       @gibbon.say_hello
     end
   end


### PR DESCRIPTION
Mailchimp doesn't provide me a key with datacenter tacked at the end.
They do provide datacenter information separately. We shouldn't have to
remember to do the string concats if Gibbon can handle this more
semantically.

Gemfile changes allow me to use bundler 1.1.rc2 and newer version of
jeweler.
