### PR TITLE
Adding in an example of fetching a list by the list's name

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,6 +46,10 @@ For example, to fetch your first 100 campaigns (page 0):
 Similarly, to fetch your first 100 lists:
 
     lists = gb.lists({:start => 0, :limit=> 100})
+    
+Or, to fetch a list by name:
+
+    list = gb.lists({:filters => {:list_name => list_name}})
 
 ### More Advanced Examples
 


### PR DESCRIPTION
Hello,

It took me a bit to figure out how to fetch a single list by the list's name using Gibbon.  I thought it might be useful to add it to the documentation.

Thanks!
