### PR TITLE
[lib] Interpolating string in the case that response.body is nil; prevents Exceptions

### DIFF
--- a/lib/gibbon.rb
+++ b/lib/gibbon.rb
@@ -42,7 +42,7 @@ class Gibbon
     # MailChimp API sometimes returns JSON fragments (e.g. true from listSubscribe)
     # so we parse after adding brackets to create a JSON array so 
     # JSON.parse succeeds in those cases.
-    parsed_response = JSON.parse('[' + response.body + ']').first
+    parsed_response = JSON.parse("[#{response.body}]").first
 
     if should_raise_for_response?(parsed_response)
       raise MailChimpError.new("MailChimp API Error: #{parsed_response["error"]} (code #{parsed_response["code"]})")


### PR DESCRIPTION
Hello, there!

Thanks for your steadfast contributions and maintenance of this gem!  It's made its way into a few projects I work on, and I appreciate every commit :)

I've noticed that a call to `'[' + response.body + ']'` in the `call` method of Gibbon will result in an Exception being thrown in the case that response.body is nil. 

Ideally, the mailchimp API should never return such a response, but I had some trouble today integrating the latest version of gibbon (that included this funcitonality) with various web-mocking libraries I use for my testing suites.

Perhaps this is an indication that these web-mocking libraries might have to change, or that more rigorous mocking should be done on the client's behalf, but the error struck me as something that could be avoided easily with string interpoloation, and potentially valuable later on down the line should the situation ever arise.

At any rate, thanks for continuing to work on this gem :+1:

Thanks in advance :) 
