### PR TITLE
Require multi_json greater than 1.3.4 for compatibility with multi_json dump. 

### DIFF
--- a/gibbon.gemspec
+++ b/gibbon.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('httparty')
-  s.add_dependency('multi_json')
+  s.add_dependency('multi_json', '>= 1.3.4')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('debugger')


### PR DESCRIPTION
...Gibbon uses the .dump method introduced in that multi_json release.
