### PR TITLE
Ensure that initializer option 'throws_exceptions' is properly stored

### DIFF
--- a/lib/gibbon/api.rb
+++ b/lib/gibbon/api.rb
@@ -8,7 +8,7 @@ module Gibbon
 
       @api_endpoint = default_parameters.delete(:api_endpoint) || self.class.api_endpoint
       @timeout = default_parameters.delete(:timeout) || self.class.timeout
-      @throws_exceptions = default_parameters.delete(:throws_exceptions) || self.class.throws_exceptions
+      @throws_exceptions = default_parameters.has_key?(:throws_exceptions) ? default_parameters.delete(:throws_exceptions) : self.class.throws_exceptions
   
       @default_params = {apikey: @api_key}.merge(default_parameters)
     end

--- a/spec/gibbon/gibbon_spec.rb
+++ b/spec/gibbon/gibbon_spec.rb
@@ -44,6 +44,11 @@ describe Gibbon do
       @gibbon = Gibbon::API.new(@api_key, :api_endpoint => api_endpoint)
       expect(api_endpoint).to eq(@gibbon.api_endpoint)
     end
+
+    it "sets the 'throws_exceptions' option from initializer parameters" do
+      @gibbon = Gibbon::API.new(@api_key, :throws_exceptions => false)
+      expect(false).to eq(@gibbon.throws_exceptions)
+    end
   end
 
   describe "build api url" do


### PR DESCRIPTION
Change how :throws_exceptions is extracted from default_parameters in the API initializer, fixes issue #52.
