### PR TITLE
Update README to correct lists/member-info example.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -80,7 +80,7 @@ Or, to fetch a list by name:
 
 Getting batch member information for subscribers looks like this:
 
-    info = gb.lists.member_info({:id => list_id, :email_address => email_array})
+    info = gb.lists.member_info({:id => list_id, :emails => email_array})
 
 List subscribers for a list:
 


### PR DESCRIPTION
To pass emails to the `lists/member-info` API call, the required key is `:emails` and not `:email_addresses`. See documentation here:

http://apidocs.mailchimp.com/api/2.0/lists/member-info.php
