### PR TITLE
Improve lists.member_info example.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -80,7 +80,7 @@ Or, to fetch a list by name:
 
 Getting batch member information for subscribers looks like this:
 
-    info = gb.lists.member_info({:id => list_id, :emails => email_array})
+    info = gb.lists.member_info({:id => list_id, :emails => [{:email => email_1}, {:email => email_2}]})
 
 List subscribers for a list:
 


### PR DESCRIPTION
The current example gives the impression that the argument is an array of String values.
