### PR TITLE
Support Partner API

### DIFF
--- a/lib/gibbon.rb
+++ b/lib/gibbon.rb
@@ -6,6 +6,7 @@ require 'gibbon/mailchimp_error'
 require 'gibbon/api_category'
 require 'gibbon/api'
 require 'gibbon/export'
+require 'gibbon/partner'
 
 module Gibbon
 end

--- a/lib/gibbon/partner.rb
+++ b/lib/gibbon/partner.rb
@@ -1,0 +1,65 @@
+module Gibbon
+  class Partner < APICategory
+
+    def initialize(app_key = nil, api_key = nil, default_params = {})
+      @app_key = app_key
+      @api_key = api_key
+      @default_params = default_params
+
+      set_instance_defaults
+    end
+
+    protected
+
+    def partner_api_url
+      "https://#{get_data_center_from_api_key}partner-api.mailchimp.com/1.3/"
+    end
+
+    def call(method, params = {})
+      api_url = "#{partner_api_url}?method=#{method}"
+      params = @default_params.merge(params).merge({:apikey => @api_key, :app_key => @app_key})
+      response = self.class.post(api_url, :body => MultiJson.dump(params), :timeout => @timeout)
+
+      lines = response.body.lines
+      if @throws_exceptions
+        first_line = MultiJson.load(lines.first) if lines.first
+
+        if should_raise_for_response?(first_line)
+          error = MailChimpError.new("MailChimp Partner API Error: #{first_line["error"]} (code #{first_line["code"]})")
+          error.code = first_line["code"]
+          raise error
+        end
+      end
+
+      lines
+    end
+
+    def set_instance_defaults
+      super
+      @api_key = self.class.api_key if @api_key.nil?
+      @timeout = self.class.timeout if @timeout.nil?
+    end
+
+    def method_missing(method, *args)
+      # To support underscores, we camelize the method name
+
+      # Thanks for the camelize gsub, Rails
+      method = method.to_s.gsub(/\/(.?)/) { "::#{$1.upcase}" }.gsub(/(?:^|_)(.)/) { $1.upcase }
+
+      # We need to downcase the first letter of every API method
+      # and MailChimp has a few of API methods that end in "AIM," which
+      # must be upcased (See "Campaign Report Data Methods" in their API docs).
+      method = method[0].chr.downcase + method[1..-1].gsub(/aim$/i, 'AIM')
+
+      call(method, *args)
+    end
+
+    class << self
+      attr_accessor :api_key, :timeout, :throws_exceptions
+
+      def method_missing(sym, *args, &block)
+        new(self.api_key, {:timeout => self.timeout, :throws_exceptions => self.throws_exceptions}).send(sym, *args, &block)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds support for the Partner API (http://apidocs.mailchimp.com/partnerapi/) — based largely on `export.rb`