### PR TITLE
ensure that we have an API Key before making a request to avoid SSL erro...

### DIFF
--- a/lib/gibbon.rb
+++ b/lib/gibbon.rb
@@ -2,6 +2,7 @@ require 'httparty'
 require 'multi_json'
 require 'cgi'
 
+require 'gibbon/gibbon_error'
 require 'gibbon/mailchimp_error'
 require 'gibbon/api_category'
 require 'gibbon/api'

--- a/lib/gibbon/api_category.rb
+++ b/lib/gibbon/api_category.rb
@@ -20,6 +20,8 @@ module Gibbon
     end
 
     def call(method, params = {})
+      ensure_api_key params
+
       api_url = base_api_url + method
       params = @default_params.merge(params).merge({:apikey => @api_key})
       headers = params.delete(:headers) || {}
@@ -87,6 +89,15 @@ module Gibbon
       end
 
       data_center
+    end
+
+
+    private
+
+    def ensure_api_key(params)
+      unless @api_key || @default_params[:apikey] || params[:apikey]
+        raise Gibbon::GibbonError, "You must set an api_key prior to making a call"
+      end
     end
   end
 end

--- a/lib/gibbon/export.rb
+++ b/lib/gibbon/export.rb
@@ -15,6 +15,8 @@ module Gibbon
     end
 
     def call(method, params = {})
+      ensure_api_key params
+
       api_url = export_api_url + method + "/"
       params = @default_params.merge(params).merge({:apikey => @api_key})
       response = self.class.post(api_url, :body => MultiJson.dump(params), :timeout => @timeout)
@@ -55,6 +57,15 @@ module Gibbon
 
     def respond_to_missing?(method, include_private = false)
       %w{list ecommOrders ecomm_orders campaignSubscriberActivity campaign_subscriber_activity}.include?(method.to_s) || super
+    end
+
+
+    private
+
+    def ensure_api_key(params)
+      unless @api_key || @default_params[:apikey] || params[:apikey]
+        raise Gibbon::GibbonError, "You must set an api_key prior to making a call"
+      end
     end
 
     class << self

--- a/lib/gibbon/gibbon_error.rb
+++ b/lib/gibbon/gibbon_error.rb
@@ -1,0 +1,3 @@
+module Gibbon
+  class GibbonError < StandardError; end
+end

--- a/spec/gibbon/gibbon_spec.rb
+++ b/spec/gibbon/gibbon_spec.rb
@@ -57,9 +57,8 @@ describe Gibbon do
       @url = "https://api.mailchimp.com/2.0/say/hello"
     end
 
-    it "handle empty api key" do
-      expect_post(@url, {"apikey" => nil})
-      @gibbon.say.hello
+    it "doesn't allow empty api key" do
+      expect {@gibbon.say.hello}.to raise_error(Gibbon::GibbonError)
     end
 
     it "handle malformed api key" do
@@ -70,7 +69,8 @@ describe Gibbon do
     end
 
     it "handle timeout" do
-      expect_post(@url, {"apikey" => nil}, 120)
+      expect_post(@url, {"apikey" => 'test'}, 120)
+      @gibbon.api_key = 'test'
       @gibbon.timeout=120
       @gibbon.say.hello
     end


### PR DESCRIPTION
We ran into strange behavior recently with one of our applications.  It wasn't immediately obvious that our Mailchimp API key wasn't set in the application environment and when attempting an API request we would receive an SSL Error for a hostname mismatch on the certificate.

This change makes sure that an API_KEY is set at the time a request is made to the MailChimp API.  Hopefully this saves someone else from a few hours of debugging.
