### PR TITLE
include error name in mailchimp error

### DIFF
--- a/lib/gibbon/api_category.rb
+++ b/lib/gibbon/api_category.rb
@@ -35,6 +35,7 @@ module Gibbon
         if should_raise_for_response?(parsed_response)
           error = MailChimpError.new(parsed_response["error"])
           error.code = parsed_response["code"]
+          error.name = parsed_response["name"]
           raise error
         end
       end

--- a/lib/gibbon/mailchimp_error.rb
+++ b/lib/gibbon/mailchimp_error.rb
@@ -1,5 +1,5 @@
 module Gibbon
   class MailChimpError < StandardError
-    attr_accessor :code
+    attr_accessor :code, :name
   end
 end


### PR DESCRIPTION
It's useful to be able to access the name of the Mailchimp error since they are referred to in the docs and there doesn't seem to be (at least that I can find) a reference of v2.0 error codes.
