### PR TITLE
Updating MultiJSON dependency to 1.9.0

### DIFF
--- a/gibbon.gemspec
+++ b/gibbon.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('httparty')
-  s.add_dependency('multi_json', '>= 1.3.4')
+  s.add_dependency('multi_json', '>= 1.9.0')
 
   s.add_development_dependency 'rake'
   s.add_development_dependency "rspec", "2.14.1"


### PR DESCRIPTION
Previously required version of MultiJson (1.3.4) does not have support for ParseError.

But Gibbon depends on it in at least one place:  https://github.com/amro/gibbon/blob/master/lib/gibbon/api_category.rb#L35
`rescue MultiJson::ParseError`

The ParseError module didn’t exist (or was called LoadError) until MultiJson v 1.9.0: https://github.com/intridea/multi_json/blob/master/CHANGELOG.md

You would need at least MultiJson 1.9.0 for current release to not have this bug.
