### PR TITLE
Fix typo in export list example usage

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -190,7 +190,7 @@ of JSON objects rather than a single JSON array.
 
 For example, dumping list members via the "list" method works like this:
 
-    gibbon_export.list({id => list_id})
+    gibbon_export.list({:id => list_id})
 
 ##Thanks
 


### PR DESCRIPTION
Without the colon you'll get a "undefined local variable or method `id`" error.