### PR TITLE
Eport API: Zero length response gacks with "undefined method `strip' for nil:NilClass"

### DIFF
--- a/lib/gibbon/export.rb
+++ b/lib/gibbon/export.rb
@@ -24,7 +24,7 @@ module Gibbon
       lines = response.body.lines
       if @throws_exceptions
         # ignore blank responses
-        return [] if lines.first.strip.empty?
+        return [] if !lines.first || lines.first.strip.empty?
 
         first_line = MultiJson.load(lines.first) if lines.first
 

--- a/spec/gibbon/gibbon_spec.rb
+++ b/spec/gibbon/gibbon_spec.rb
@@ -260,9 +260,16 @@ describe Gibbon do
       expect {@gibbon.say_hello(@body)}.to raise_error(Gibbon::MailChimpError)
     end
 
-    it "should handle a blank response without throwing an exception" do
+    it "should handle a single empty space response without throwing an exception" do
       @gibbon.throws_exceptions = true
-      allow(Gibbon::Export).to receive(:post).and_return(Struct.new(:body).new(Struct.new(:lines).new([" "])))
+      allow(Gibbon::Export).to receive(:post).and_return(Struct.new(:body).new(" "))
+
+      expect(@gibbon.say_hello(@body)).to eq([])
+    end
+
+    it "should handle an empty response without throwing an exception" do
+      @gibbon.throws_exceptions = true
+      allow(Gibbon::Export).to receive(:post).and_return(Struct.new(:body).new(""))
 
       expect(@gibbon.say_hello(@body)).to eq([])
     end


### PR DESCRIPTION
I reported #102 back in November to MC and they said that the Export API was permanently changed to return a single empty space as the response payload if there was nothing to return. #102 fixed that, but starting recently, MC has reverted back to the old behavior of returning a zero length response.

This patch to the patch should accommodate for both scenarios