### PR TITLE
Fix bug where export timeout doesn't get set

### DIFF
--- a/lib/gibbon/export.rb
+++ b/lib/gibbon/export.rb
@@ -39,9 +39,9 @@ module Gibbon
     end
 
     def set_instance_defaults
-      super
       @api_key = self.class.api_key if @api_key.nil?
       @timeout = self.class.timeout if @timeout.nil?
+      super
     end
 
     def method_missing(method, *args)

--- a/spec/gibbon/gibbon_spec.rb
+++ b/spec/gibbon/gibbon_spec.rb
@@ -244,6 +244,11 @@ describe Gibbon do
       @gibbon.say_hello(@body)
     end
 
+    it "uses timeout if set" do
+      Gibbon::Export.timeout = 45
+      expect(Gibbon::Export.new.timeout).to eql 45
+    end
+
     it "not throw exception if the Export API replies with a JSON hash containing a key called 'error'" do
       @gibbon.throws_exceptions = false
       allow(Gibbon::Export).to receive(:post).and_return(Struct.new(:body).new(MultiJson.dump({'error' => 'bad things'})))


### PR DESCRIPTION
Currently setting `Gibbon::Export.timeout` does not work. It instead uses the value set for `Gibbon::API` or the default.

**Current:**
```Ruby
Gibbon::Export.timeout = 45
export = Gibbon::Export.new
export.timeout
=> 30
```

This change fixes it.

**After:**
```Ruby
Gibbon::Export.timeout = 45
export = Gibbon::Export.new
export.timeout
=> 45
```