### PR TITLE
Expand args for __send__ at ApiCategory#send

### DIFF
--- a/lib/gibbon/api_category.rb
+++ b/lib/gibbon/api_category.rb
@@ -60,7 +60,7 @@ module Gibbon
       if ((args.length > 0) && args[0].is_a?(Hash))
         method_missing(:send, args[0])
       else
-        __send__(args)
+        __send__(*args)
       end
     end
 


### PR DESCRIPTION
If I got it right this fixes issue with calling the Export methods right on the class without creating an instance, which now throws an error:
```
TypeError: [:campaignSubscriberActivity, {:id=>"ed447bec9e"}] is not a symbol
        from /home/dveleba/.rvm/gems/ruby-2.1.6@commstat/gems/gibbon-1.1.6/lib/gibbon/api_category.rb:63:in `send'
        from /home/dveleba/.rvm/gems/ruby-2.1.6@commstat/gems/gibbon-1.1.6/lib/gibbon/export.rb:108:in `method_missing'
```