### PR TITLE
fix newline issue when parsing from export API

### DIFF
--- a/lib/gibbon/export.rb
+++ b/lib/gibbon/export.rb
@@ -34,6 +34,7 @@ module Gibbon
           last = ''
           response.read_body do |chunk|
             next if chunk.nil? or chunk.strip.empty?
+            last += "\n" if last[-1,1]=="]"
             lines = (last+chunk).split("\n")
             last = lines.pop || ''
             lines.each do |line|


### PR DESCRIPTION
Simple fix to add a newline when reading from the export API, see issue https://github.com/amro/gibbon/issues/125.