### PR TITLE
Support upsert requests

### DIFF
--- a/gibbon.gemspec
+++ b/gibbon.gemspec
@@ -30,5 +30,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency "rspec", "3.2.0"
+  s.add_development_dependency 'webmock', '~> 1.21.0'
 
 end

--- a/lib/gibbon/api_request.rb
+++ b/lib/gibbon/api_request.rb
@@ -29,6 +29,19 @@ module Gibbon
         handle_error(e)
       end
     end
+
+    def put(params: nil, headers: nil, body: nil)
+      validate_api_key
+
+      begin
+        response = self.rest_client.put do |request|
+          configure_request(request: request, params: params, headers: headers, body: MultiJson.dump(body))
+        end
+        parse_response(response.body)
+      rescue => e
+        handle_error(e)
+      end
+    end
     
     def get(params: nil, headers: nil)
       validate_api_key

--- a/lib/gibbon/request.rb
+++ b/lib/gibbon/request.rb
@@ -36,6 +36,12 @@ module Gibbon
       reset
     end
 
+    def upsert(params: nil, headers: nil, body: nil)
+      APIRequest.new(builder: self).put(params: params, headers: headers, body: body)
+    ensure
+      reset
+    end
+
     def retrieve(params: nil, headers: nil)
       APIRequest.new(builder: self).get(params: params, headers: headers)
     ensure

--- a/spec/gibbon/upsert_spec.rb
+++ b/spec/gibbon/upsert_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'webmock/rspec'
+require 'digest/md5'
+
+describe Gibbon do
+  let(:api_key) { '1234-us1' }
+  let(:list_id) { 'testlist' }
+  let(:email) { 'john.doe@example.com' }
+  let(:member_id) { Digest::MD5.hexdigest(email) }
+
+  let(:request_body) do
+    {
+      email_address: email,
+      status: 'subscribed',
+      merge_fields: {FNAME: 'John', LNAME: 'Doe'}
+    }
+  end
+
+  it 'supports upsert request' do
+    stub_request(:put, "https://apikey:1234-us1@us1.api.mailchimp.com/3.0/lists/#{list_id}/members/#{member_id}")
+      .with(body: MultiJson.dump(request_body))
+      .to_return(status: 200)
+
+    Gibbon::Request.new(api_key: api_key)
+      .lists(list_id).members(member_id)
+      .upsert(body: request_body)
+  end
+end


### PR DESCRIPTION
Upsert requests (using PUT method) are useful to update existing or
create a new entity within a single API call.