### PR TITLE
Fix how unparseable Faraday request exception is surfaced

### DIFF
--- a/lib/gibbon/mailchimp_error.rb
+++ b/lib/gibbon/mailchimp_error.rb
@@ -1,5 +1,5 @@
 module Gibbon
   class MailChimpError < StandardError
-    attr_accessor :title, :detail, :body, :raw_body, :status_code
+    attr_accessor :title, :detail, :body, :raw_body, :status_code, :message
   end
 end

--- a/spec/gibbon/api_request_spec.rb
+++ b/spec/gibbon/api_request_spec.rb
@@ -9,8 +9,17 @@ describe Gibbon::APIRequest do
     @api_root = "https://apikey:#{api_key}@us1.api.mailchimp.com/3.0"
   end
 
-  it "surfaces request exceptions as Gibbon::MailChimpError exceptions" do
-    stub_request(:get, "#{@api_root}/lists").to_raise(StandardError)
+  it "surfaces client request exceptions as a Gibbon::MailChimpError" do
+    exception = Faraday::Error::ClientError.new("the server responded with status 503")
+    stub_request(:get, "#{@api_root}/lists").to_raise(exception)
+    expect { @gibbon.lists.retrieve }.to raise_error(Gibbon::MailChimpError)
+  end
+
+  it "surfaces an unparseable response body as a Gibbon::MailChimpError" do
+    response_values = {:status => 503, :headers => {}, :body => '[foo]'}
+    exception = Faraday::Error::ClientError.new("the server responded with status 503", response_values)
+
+    stub_request(:get, "#{@api_root}/lists").to_raise(exception)
     expect { @gibbon.lists.retrieve }.to raise_error(Gibbon::MailChimpError)
   end
 end

--- a/spec/gibbon/api_request_spec.rb
+++ b/spec/gibbon/api_request_spec.rb
@@ -15,6 +15,13 @@ describe Gibbon::APIRequest do
     expect { @gibbon.lists.retrieve }.to raise_error(Gibbon::MailChimpError)
   end
 
+  it "surfaces an unparseable client request exception as a Gibbon::MailChimpError" do
+    exception = Faraday::Error::ClientError.new(
+      "the server responded with status 503")
+    stub_request(:get, "#{@api_root}/lists").to_raise(exception)
+    expect { @gibbon.lists.retrieve }.to raise_error(Gibbon::MailChimpError)
+  end
+
   it "surfaces an unparseable response body as a Gibbon::MailChimpError" do
     response_values = {:status => 503, :headers => {}, :body => '[foo]'}
     exception = Faraday::Error::ClientError.new("the server responded with status 503", response_values)

--- a/spec/gibbon/api_request_spec.rb
+++ b/spec/gibbon/api_request_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+require 'webmock/rspec'
+
+describe Gibbon::APIRequest do
+  let(:api_key) { "1234-us1" }
+
+  before do
+    @gibbon = Gibbon::Request.new(api_key: api_key)
+    @api_root = "https://apikey:#{api_key}@us1.api.mailchimp.com/3.0"
+  end
+
+  it "surfaces request exceptions as Gibbon::MailChimpError exceptions" do
+    stub_request(:get, "#{@api_root}/lists").to_raise(StandardError)
+    expect { @gibbon.lists.retrieve }.to raise_error(Gibbon::MailChimpError)
+  end
+end


### PR DESCRIPTION
This fixes #154.

It appeared that the intention of [this line](https://github.com/amro/gibbon/blob/439a321bea4abb08c6e9de16f6cbecfa110e69c5/lib/gibbon/api_request.rb#L109) originally via b021d1294593746d9c0aaa70bb5b258292e0e374 to have a `MailChimpError#message` method, as I've added in this PR.

If it'd be better to use one of the existing instance methods on `MailChimpError` class, just lemme know and I'll update this.

Cheers! :beers: 