### PR TITLE
Allow Farady default_connection_options

### DIFF
--- a/lib/gibbon/api_request.rb
+++ b/lib/gibbon/api_request.rb
@@ -124,7 +124,7 @@ module Gibbon
     end
 
     def rest_client
-      client = Faraday.new(url: self.api_url) do |faraday|
+      client = Faraday.new(self.api_url) do |faraday|
         faraday.response :raise_error
         faraday.adapter Faraday.default_adapter
       end


### PR DESCRIPTION
If Faraday.new is called with the string url as first parameter,
default_connection_options are respected. This allows i.e. to set ssl
options to Faraday prior to Gibbon actions.
Currently the cert chain of the endpoint I'm using is broken, so all calls fail with SSL errors.
Instead of overwriting OpenSSL constants to set verify to false, with this patch I can temporarily change SSL-Options like
```ruby
Faraday.default_connection_options[:ssl] = Faraday::SSLOptions.new(false)
gibbon.lists.retrieve
Faraday.default_connection_options[:ssl] = nil
```