### PR TITLE
Proxy Support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,6 +32,12 @@ You can set an individual request's timeout like this:
 gibbon.timeout = 10
 ```
 
+You can set an optional proxy url like this:
+
+```ruby
+gibbon.proxy = 'http://your_proxy_url.com:80'
+```
+
 Now you can make requests using the resources defined in [MailChimp's docs](http://kb.mailchimp.com/api/resources). Resource IDs
 are specified inline and a `CRUD` (`create`, `retrieve`, `update`, `upsert`, or `delete`) verb initiates the request. `upsert` lets you update a record, if it exists, or insert it otherwise where supported by MailChimp's API.
 

--- a/lib/gibbon/api_request.rb
+++ b/lib/gibbon/api_request.rb
@@ -84,6 +84,10 @@ module Gibbon
     def timeout
       @request_builder.timeout
     end
+    
+    def proxy_url
+      @request_builder.proxy_url
+    end
 
     # Helpers
 
@@ -124,7 +128,7 @@ module Gibbon
     end
 
     def rest_client
-      client = Faraday.new(self.api_url) do |faraday|
+      client = Faraday.new(self.api_url, proxy: self.proxy_url) do |faraday|
         faraday.response :raise_error
         faraday.adapter Faraday.default_adapter
       end

--- a/lib/gibbon/request.rb
+++ b/lib/gibbon/request.rb
@@ -1,15 +1,16 @@
 module Gibbon
   class Request
-    attr_accessor :api_key, :api_endpoint, :timeout
+    attr_accessor :api_key, :api_endpoint, :timeout, :proxy_url
 
     DEFAULT_TIMEOUT = 30
 
-    def initialize(api_key: nil, api_endpoint: nil, timeout: nil)
+    def initialize(api_key: nil, api_endpoint: nil, timeout: nil, proxy_url: nil)
       @path_parts = []
       @api_key = api_key || self.class.api_key || ENV['MAILCHIMP_API_KEY']
       @api_key = @api_key.strip if @api_key
       @api_endpoint = api_endpoint || self.class.api_endpoint
       @timeout = timeout || self.class.timeout || DEFAULT_TIMEOUT
+      @proxy_url = proxy_url || self.class.proxy_url || ENV['MAILCHIMP_PROXY_URL']
     end
 
     def method_missing(method, *args)
@@ -61,10 +62,10 @@ module Gibbon
     end
 
     class << self
-      attr_accessor :api_key, :timeout, :api_endpoint
+      attr_accessor :api_key, :timeout, :api_endpoint, :proxy_url
 
       def method_missing(sym, *args, &block)
-        new(api_key: self.api_key, api_endpoint: self.api_endpoint, timeout: self.timeout).send(sym, *args, &block)
+        new(api_key: self.api_key, api_endpoint: self.api_endpoint, timeout: self.timeout, proxy_url: self.proxy_url).send(sym, *args, &block)
       end
     end
   end

--- a/spec/gibbon/gibbon_spec.rb
+++ b/spec/gibbon/gibbon_spec.rb
@@ -7,13 +7,14 @@ describe Gibbon do
       Gibbon::APIRequest.send(:public, *Gibbon::APIRequest.protected_instance_methods)
 
       @api_key = "123-us1"
+      @proxy_url = 'the_proxy_url'
     end
 
     it "have no API by default" do
       @gibbon = Gibbon::Request.new
       expect(@gibbon.api_key).to be_nil
     end
-
+    
     it "set an API key in constructor" do
       @gibbon = Gibbon::Request.new(api_key: @api_key)
       expect(@gibbon.api_key).to eq(@api_key)
@@ -52,6 +53,24 @@ describe Gibbon do
       @gibbon = Gibbon::Request.new(api_key: @api_key, api_endpoint: api_endpoint)
       expect(api_endpoint).to eq(@gibbon.api_endpoint)
     end
+    
+    it "have no Proxy url by default" do
+      @gibbon = Gibbon::Request.new
+      expect(@gibbon.proxy_url).to be_nil
+    end    
+
+    it "set an proxy url key from the 'MAILCHIMP_PROXY_URL' ENV variable" do
+      ENV['MAILCHIMP_PROXY_URL'] = @proxy_url
+      @gibbon = Gibbon::Request.new
+      expect(@gibbon.proxy_url).to eq(@proxy_url)
+      ENV.delete('MAILCHIMP_PROXY_URL')
+    end  
+    
+    it "set an API key via setter" do
+      @gibbon = Gibbon::Request.new
+      @gibbon.proxy_url = @proxy_url
+      expect(@gibbon.proxy_url).to eq(@proxy_url)
+    end    
   end
 
   describe "build api url" do
@@ -117,4 +136,3 @@ describe Gibbon do
     end
   end
 end
-


### PR DESCRIPTION
These changes make it possible to specify an optional proxy url for making requests to MailChimp. 