### PR TITLE
Do not override MailChimpError @message, fix #170

### DIFF
--- a/lib/gibbon/api_request.rb
+++ b/lib/gibbon/api_request.rb
@@ -84,7 +84,7 @@ module Gibbon
     def timeout
       @request_builder.timeout
     end
-    
+
     def proxy
       @request_builder.proxy
     end
@@ -96,11 +96,9 @@ module Gibbon
     # Helpers
 
     def handle_error(error)
-      error_to_raise = nil
+      error_to_raise = MailChimpError.new(error.message)
 
       begin
-        error_to_raise = MailChimpError.new(error.message)
-
         if error.is_a?(Faraday::Error::ClientError) && error.response
           parsed_response = MultiJson.load(error.response[:body])
 
@@ -114,7 +112,6 @@ module Gibbon
           error_to_raise.raw_body = error.response[:body]
         end
       rescue MultiJson::ParseError
-        error_to_raise.message = error.message
         error_to_raise.status_code = error.response[:status]
       end
 

--- a/lib/gibbon/mailchimp_error.rb
+++ b/lib/gibbon/mailchimp_error.rb
@@ -1,5 +1,5 @@
 module Gibbon
   class MailChimpError < StandardError
-    attr_accessor :title, :detail, :body, :raw_body, :status_code, :message
+    attr_accessor :title, :detail, :body, :raw_body, :status_code
   end
 end


### PR DESCRIPTION
We don't need to reassign `@message` because it is assigned during error init:

```ruby
error_to_raise = MailChimpError.new(error.message)
```

Fixes #170 