### PR TITLE
Make MailChimpError printing more informative

### DIFF
--- a/lib/gibbon/api_request.rb
+++ b/lib/gibbon/api_request.rb
@@ -96,24 +96,26 @@ module Gibbon
     # Helpers
 
     def handle_error(error)
-      error_to_raise = MailChimpError.new(error.message)
+      error_params = {}
 
       begin
         if error.is_a?(Faraday::Error::ClientError) && error.response
           parsed_response = MultiJson.load(error.response[:body])
 
           if parsed_response
-            error_to_raise.body = parsed_response
-            error_to_raise.title = parsed_response["title"] if parsed_response["title"]
-            error_to_raise.detail = parsed_response["detail"] if parsed_response["detail"]
+            error_params[:body] = parsed_response
+            error_params[:title] = parsed_response["title"] if parsed_response["title"]
+            error_params[:detail] = parsed_response["detail"] if parsed_response["detail"]
           end
 
-          error_to_raise.status_code = error.response[:status]
-          error_to_raise.raw_body = error.response[:body]
+          error_params[:status_code] = error.response[:status]
+          error_params[:raw_body] = error.response[:body]
         end
       rescue MultiJson::ParseError
-        error_to_raise.status_code = error.response[:status]
+        error_params[:status_code] = error.response[:status]
       end
+
+      error_to_raise = MailChimpError.new(error.message, error_params)
 
       raise error_to_raise
     end

--- a/lib/gibbon/mailchimp_error.rb
+++ b/lib/gibbon/mailchimp_error.rb
@@ -1,5 +1,29 @@
 module Gibbon
   class MailChimpError < StandardError
-    attr_accessor :title, :detail, :body, :raw_body, :status_code
+    attr_reader :title, :detail, :body, :raw_body, :status_code
+
+    def initialize(message = "", params = {})
+      @title       = params[:title]
+      @detail      = params[:detail]
+      @body        = params[:body]
+      @raw_body    = params[:raw_body]
+      @status_code = params[:status_code]
+
+      super(message)
+    end
+
+    def to_s
+      super + " " + instance_variables_to_s
+    end
+
+    private
+
+    def instance_variables_to_s
+      [:title, :detail, :body, :raw_body, :status_code].map do |attr|
+        attr_value = send(attr)
+
+        "@#{attr}=#{attr_value.inspect}"
+      end.join(", ")
+    end
   end
 end


### PR DESCRIPTION
This changes the way how `MailChimpError` exception looks for printing in console and e.g. for Sidekiq retries queue.  
Instead of

```ruby
Gibbon::MailChimpError the server responded with status 400
```

It will also print all the valuable instance variables

```ruby
Gibbon::MailChimpError the server responded with status 400 @title="Member Exists", @detail="john@example.com is already a list member. Use PUT to insert or update list members.", @body={"type"=>"http://developer.mailchimp.com/documentation/mailchimp/guides/error-glossary/", "title"=>"Member Exists", "status"=>400, "detail"=>"john@example.com is already a list member. Use PUT to insert or update list members.", "instance"=>""}, @raw_body="{\"type\":\"http://developer.mailchimp.com/documentation/mailchimp/guides/error-glossary/\",\"title\":\"Member Exists\",\"status\":400,\"detail\":\"john@example.com is already a list member. Use PUT to insert or update list members.\",\"instance\":\"\"}", @status_code=400
```

Makes it easier to debug the exception without reproducing it locally.