### PR TITLE
Use email hash for all list members actions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -114,7 +114,7 @@ gibbon.lists(list_id).members(lower_case_md5_hashed_email_address).upsert(body: 
 You can also unsubscribe a member from a list:
 
 ```ruby
-gibbon.lists(list_id).members(member_id).update(body: { status: "unsubscribed" })
+gibbon.lists(list_id).members(lower_case_md5_hashed_email_address).update(body: { status: "unsubscribed" })
 ```
 
 ### Campaigns


### PR DESCRIPTION
`lower_case_md5_hashed_email_address` is used for all `#members` actions where some kind of id is needed.