### PR TITLE
Added an example of scheduling a campaign

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -266,6 +266,18 @@ Send a campaign:
 gibbon.campaigns(campaign_id).actions.send.create
 ```
 
+Schedule a campaign:
+
+```ruby
+body = {
+  schedule_time: "2016-06-27 20:00:00"
+}
+```
+
+```ruby
+gibbon.campaigns(campaign_id).actions.schedule.create(body: body)
+```
+
 ### Interests
 
 Interests are a little more complicated than other parts of the API, so here's an example of how you would set interests during at subscription time or update them later. The ID of the interests you want to opt in or out of must be known ahead of time so an example of how to find interest IDs is also included.


### PR DESCRIPTION
Just a basic example of scheduling a campaign added to the (already awesome) readme