### PR TITLE
added the response headers attribute accessor to allow parsing useful info

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -300,6 +300,16 @@ body = {
 gibbon.campaigns(campaign_id).actions.schedule.create(body: body)
 ```
 
+### Response headers
+
+Some information is inside the response headers, such as the admin URL one can use to redirect to after the creation of a campaign. As such, the reply headers object can be retrieved:
+
+```ruby
+campaigns_obj = gibbon.campaigns
+campaigns_obj.create(body: body)
+response_headers = campaigns_obj.response_headers
+```
+
 ### Interests
 
 Interests are a little more complicated than other parts of the API, so here's an example of how you would set interests during at subscription time or update them later. The ID of the interests you want to opt in or out of must be known ahead of time so an example of how to find interest IDs is also included.

--- a/lib/gibbon/api_request.rb
+++ b/lib/gibbon/api_request.rb
@@ -1,5 +1,7 @@
 module Gibbon
   class APIRequest
+    attr_accessor :response_headers
+
     def initialize(builder: nil)
       @request_builder = builder
     end
@@ -11,6 +13,7 @@ module Gibbon
         response = self.rest_client.post do |request|
           configure_request(request: request, params: params, headers: headers, body: MultiJson.dump(body))
         end
+        @response_headers = response.headers
         parse_response(response.body)
       rescue => e
         handle_error(e)
@@ -24,6 +27,7 @@ module Gibbon
         response = self.rest_client.patch do |request|
           configure_request(request: request, params: params, headers: headers, body: MultiJson.dump(body))
         end
+        @response_headers = response.headers
         parse_response(response.body)
       rescue => e
         handle_error(e)
@@ -37,6 +41,7 @@ module Gibbon
         response = self.rest_client.put do |request|
           configure_request(request: request, params: params, headers: headers, body: MultiJson.dump(body))
         end
+        @response_headers = response.headers
         parse_response(response.body)
       rescue => e
         handle_error(e)
@@ -50,6 +55,7 @@ module Gibbon
         response = self.rest_client.get do |request|
           configure_request(request: request, params: params, headers: headers)
         end
+        @response_headers = response.headers
         parse_response(response.body)
       rescue => e
         handle_error(e)
@@ -63,6 +69,7 @@ module Gibbon
         response = self.rest_client.delete do |request|
           configure_request(request: request, params: params, headers: headers)
         end
+        @response_headers = response.headers
         parse_response(response.body)
       rescue => e
         handle_error(e)

--- a/lib/gibbon/request.rb
+++ b/lib/gibbon/request.rb
@@ -1,6 +1,7 @@
 module Gibbon
   class Request
     attr_accessor :api_key, :api_endpoint, :timeout, :proxy, :faraday_adapter, :debug, :logger
+    attr_accessor :response_headers
 
     DEFAULT_TIMEOUT = 30
 
@@ -37,31 +38,46 @@ module Gibbon
     end
 
     def create(params: nil, headers: nil, body: nil)
-      APIRequest.new(builder: self).post(params: params, headers: headers, body: body)
+      api_request = APIRequest.new(builder: self)
+      result = api_request.post(params: params, headers: headers, body: body)
+      @response_headers = api_request.response_headers
+      result
     ensure
       reset
     end
 
     def update(params: nil, headers: nil, body: nil)
-      APIRequest.new(builder: self).patch(params: params, headers: headers, body: body)
+      api_request = APIRequest.new(builder: self)
+      result = api_request.patch(params: params, headers: headers, body: body)
+      @response_headers = api_request.response_headers
+      result
     ensure
       reset
     end
 
     def upsert(params: nil, headers: nil, body: nil)
-      APIRequest.new(builder: self).put(params: params, headers: headers, body: body)
+      api_request = APIRequest.new(builder: self)
+      result = api_request.put(params: params, headers: headers, body: body)
+      @response_headers = api_request.response_headers
+      result
     ensure
       reset
     end
 
     def retrieve(params: nil, headers: nil)
-      APIRequest.new(builder: self).get(params: params, headers: headers)
+      api_request = APIRequest.new(builder: self)
+      result = api_request.get(params: params, headers: headers)
+      @response_headers = api_request.response_headers
+      result
     ensure
       reset
     end
 
     def delete(params: nil, headers: nil)
-      APIRequest.new(builder: self).delete(params: params, headers: headers)
+      api_request = APIRequest.new(builder: self)
+      result = api_request.delete(params: params, headers: headers)
+      @response_headers = api_request.response_headers
+      result
     ensure
       reset
     end


### PR DESCRIPTION
I added the response_headers attribute to Request to hold the last response headers object.
I need this because the admin URL (web_id in API V2) is returned in the headers and not in the body. So I was login that information.
I also added the following section to readme to explain:
https://github.com/nuno84/gibbon#response-headers

The problem this pull is trying to solve is described here:
https://stackoverflow.com/questions/39324653/no-web-id-in-mailchimp-api-v3

Best regards,
Nuno
