### PR TITLE
Add symbolize_keys option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -70,6 +70,12 @@ gibbon = Gibbon::Request.new
 
 ***Note*** Substitute an underscore if a resource name contains a hyphen.
 
+You can use symbols as hash keys in api responses by passing `symbolize_keys: true`.
+
+```ruby
+gibbon = Gibbon::Request.new(api_key: "your_api_key", symbolize_keys: true)
+```
+
 MailChimp's [resource documentation](http://kb.mailchimp.com/api/resources) is a list of available resources.
 
 ##Debug Logging

--- a/lib/gibbon/api_request.rb
+++ b/lib/gibbon/api_request.rb
@@ -97,6 +97,10 @@ module Gibbon
       @request_builder.faraday_adapter
     end
 
+    def symbolize_keys
+      @request_builder.symbolize_keys
+    end
+
     # Helpers
 
     def handle_error(error)
@@ -107,7 +111,7 @@ module Gibbon
           error_params[:status_code] = error.response[:status]
           error_params[:raw_body] = error.response[:body]
 
-          parsed_response = MultiJson.load(error.response[:body])
+          parsed_response = MultiJson.load(error.response[:body], symbolize_keys: symbolize_keys)
 
           if parsed_response
             error_params[:body] = parsed_response
@@ -152,7 +156,7 @@ module Gibbon
 
       if response_body && !response_body.empty?
         begin
-          parsed_response = MultiJson.load(response_body)
+          parsed_response = MultiJson.load(response_body, symbolize_keys: symbolize_keys)
         rescue MultiJson::ParseError
           error = MailChimpError.new("Unparseable response: #{response_body}")
           error.title = "UNPARSEABLE_RESPONSE"

--- a/lib/gibbon/request.rb
+++ b/lib/gibbon/request.rb
@@ -1,11 +1,11 @@
 module Gibbon
   class Request
-    attr_accessor :api_key, :api_endpoint, :timeout, :open_timeout, :proxy, :faraday_adapter, :debug, :logger
+    attr_accessor :api_key, :api_endpoint, :timeout, :open_timeout, :proxy, :faraday_adapter, :symbolize_keys, :debug, :logger
 
     DEFAULT_TIMEOUT = 30
     DEFAULT_OPEN_TIMEOUT = 60
 
-    def initialize(api_key: nil, api_endpoint: nil, timeout: nil, open_timeout: nil, proxy: nil, faraday_adapter: nil, debug: false, logger: nil)
+    def initialize(api_key: nil, api_endpoint: nil, timeout: nil, open_timeout: nil, proxy: nil, faraday_adapter: nil, symbolize_keys: false, debug: false, logger: nil)
       @path_parts = []
       @api_key = api_key || self.class.api_key || ENV['MAILCHIMP_API_KEY']
       @api_key = @api_key.strip if @api_key
@@ -14,6 +14,7 @@ module Gibbon
       @open_timeout = open_timeout || self.class.open_timeout || DEFAULT_OPEN_TIMEOUT
       @proxy = proxy || self.class.proxy || ENV['MAILCHIMP_PROXY']
       @faraday_adapter = faraday_adapter || Faraday.default_adapter
+      @symbolize_keys = symbolize_keys
       @logger = logger || self.class.logger || ::Logger.new(STDOUT)
       @debug = debug
     end

--- a/spec/gibbon/api_request_spec.rb
+++ b/spec/gibbon/api_request_spec.rb
@@ -34,7 +34,7 @@ describe Gibbon::APIRequest do
     it "includes status and raw body even when json can't be parsed" do
       response_values = {:status => 503, :headers => {}, :body => 'A non JSON response'}
       exception = Faraday::Error::ClientError.new("the server responded with status 503", response_values)
-      api_request = Gibbon::APIRequest.new
+      api_request = Gibbon::APIRequest.new(builder: Gibbon::Request)
       begin
         api_request.send :handle_error, exception
       rescue => boom

--- a/spec/gibbon/gibbon_spec.rb
+++ b/spec/gibbon/gibbon_spec.rb
@@ -92,6 +92,16 @@ describe Gibbon do
       expect(@gibbon.faraday_adapter).to eq(adapter)
     end
 
+    it "symbolize_keys false by default" do
+      @gibbon = Gibbon::Request.new
+      expect(@gibbon.symbolize_keys).to be false
+    end
+
+    it "sets symbolize_keys in the constructor" do
+      @gibbon = Gibbon::Request.new(symbolize_keys: true)
+      expect(@gibbon.symbolize_keys).to be true
+    end
+
     it "debug false by default" do
       @gibbon = Gibbon::Request.new
       expect(@gibbon.debug).to be false


### PR DESCRIPTION
If you are used to using symbols as hash keys in your code, you might want to deal with symbols in MailChimp responses too.
This Pull Request adds a `symbolize_keys` option (default to `false`), that will be passed to `MultiJson.load()` function.
