### PR TITLE
Forward #[] method to body in Gibbon::Response

### DIFF
--- a/lib/gibbon/response.rb
+++ b/lib/gibbon/response.rb
@@ -1,10 +1,14 @@
 module Gibbon
   class Response
     attr_accessor :body, :headers
-    
+
     def initialize(body: {}, headers: {})
       @body = body
       @headers = headers
-    end 
+    end
+
+    def [](key)
+      body[key]
+    end
   end
 end

--- a/spec/gibbon/response_spec.rb
+++ b/spec/gibbon/response_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+require 'cgi'
+
+describe Gibbon::Response do
+  describe "#[]" do
+    it "forwards the [] method to the body" do
+      response = Gibbon::Response.new(body: { "foo" => "bar" })
+      expect(response["foo"]).to eq "bar"
+    end
+  end
+end


### PR DESCRIPTION
This allows to use the api as follows:
``` ruby
gibbon_api.lists.retrieve["lists"].any?
```
instead of
``` ruby
gibbon_api.lists.retrieve.body["lists"].any?
```