### PR TITLE
Switch between string and symbol keys for accessing parsed_response

### DIFF
--- a/lib/gibbon/api_request.rb
+++ b/lib/gibbon/api_request.rb
@@ -117,8 +117,12 @@ module Gibbon
 
           if parsed_response
             error_params[:body] = parsed_response
-            error_params[:title] = parsed_response["title"] if parsed_response["title"]
-            error_params[:detail] = parsed_response["detail"] if parsed_response["detail"]
+
+            title_key = symbolize_keys ? :title : "title"
+            detail_key = symbolize_keys ? :detail : "detail"
+
+            error_params[:title] = parsed_response[title_key] if parsed_response[title_key]
+            error_params[:detail] = parsed_response[detail_key] if parsed_response[detail_key]
           end
 
         end

--- a/spec/gibbon/api_request_spec.rb
+++ b/spec/gibbon/api_request_spec.rb
@@ -42,5 +42,19 @@ describe Gibbon::APIRequest do
         expect(boom.raw_body).to eq "A non JSON response"
       end
     end
+
+    context "when symbolize_keys is true" do
+      it "sets title and detail on the error params" do
+        response_values = {:status => 422, :headers => {}, :body => '{"title": "foo", "detail": "bar"}'}
+        exception = Faraday::Error::ClientError.new("the server responded with status 422", response_values)
+        api_request = Gibbon::APIRequest.new(builder: Gibbon::Request.new(symbolize_keys: true))
+        begin
+          api_request.send :handle_error, exception
+        rescue => boom
+          expect(boom.title).to eq "foo"
+          expect(boom.detail).to eq "bar"
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
When `symbolize_keys` is true the `MailChimpError` title and detail fields are always nil because `ApiRequest#handle_error` uses strings to access the parsed error.

This change switches between string and symbol keys based on the value of `symbolize_keys`.