### PR TITLE
Adds spec for MailChimpError; fixes error instantiation in APIRequest

### DIFF
--- a/lib/gibbon/api_request.rb
+++ b/lib/gibbon/api_request.rb
@@ -102,7 +102,7 @@ module Gibbon
     def symbolize_keys
       @request_builder.symbolize_keys
     end
-    
+
     # Helpers
 
     def handle_error(error)
@@ -157,7 +157,7 @@ module Gibbon
       client
     end
 
-    def parse_response(response)      
+    def parse_response(response)
       parsed_response = nil
 
       if response.body && !response.body.empty?
@@ -166,9 +166,8 @@ module Gibbon
           body = MultiJson.load(response.body, symbolize_keys: symbolize_keys)
           parsed_response = Response.new(headers: headers, body: body)
         rescue MultiJson::ParseError
-          error = MailChimpError.new("Unparseable response: #{response.body}")
-          error.title = "UNPARSEABLE_RESPONSE"
-          error.status_code = 500
+          error_params = { title: "UNPARSEABLE_RESPONSE", status_code: 500 }
+          error = MailChimpError.new("Unparseable response: #{response.body}", error_params)
           raise error
         end
       end

--- a/spec/gibbon/mailchimp_error_spec.rb
+++ b/spec/gibbon/mailchimp_error_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe Gibbon::MailChimpError do
+  let(:message) { 'Foo' }
+  let(:params) do
+    {
+      title: 'error_title',
+      detail: 'error_detail',
+      body: 'error_body',
+      raw_body: 'error_raw_body',
+      status_code: 'error_status_code'
+    }
+  end
+
+  before do
+    @gibbon = Gibbon::MailChimpError.new(message, params)
+  end
+
+  it "adds the error params to the error message" do
+    expected_message = "Foo "                               \
+                       "@title=\"error_title\", "           \
+                       "@detail=\"error_detail\", "         \
+                       "@body=\"error_body\", "             \
+                       "@raw_body=\"error_raw_body\", "     \
+                       "@status_code=\"error_status_code\""
+
+    expect(@gibbon.message).to eq(expected_message)
+  end
+
+  it 'sets the title attribute' do
+    expect(@gibbon.title).to eq(params[:title])
+  end
+
+  it 'sets the detail attribute' do
+    expect(@gibbon.detail).to eq(params[:detail])
+  end
+
+  it 'sets the body attribute' do
+    expect(@gibbon.body).to eq(params[:body])
+  end
+
+  it 'sets the raw_body attribute' do
+    expect(@gibbon.raw_body).to eq(params[:raw_body])
+  end
+
+  it 'sets the status_code attribute' do
+    expect(@gibbon.status_code).to eq(params[:status_code])
+  end
+end


### PR DESCRIPTION
- Bug fix for [issue 253](https://github.com/amro/gibbon/issues/253)
- Adding specs for `Gibbon::MailChimpError`
