### PR TITLE
Enforce TLSv1.2

### DIFF
--- a/lib/gibbon/api_request.rb
+++ b/lib/gibbon/api_request.rb
@@ -146,7 +146,7 @@ module Gibbon
     end
 
     def rest_client
-      client = Faraday.new(self.api_url, proxy: self.proxy) do |faraday|
+      client = Faraday.new(self.api_url, proxy: self.proxy, ssl: { version: "TLSv1_2" }) do |faraday|
         faraday.response :raise_error
         faraday.adapter adapter
         if @request_builder.debug

--- a/lib/gibbon/export.rb
+++ b/lib/gibbon/export.rb
@@ -41,7 +41,7 @@ module Gibbon
       url = URI.parse(api_url)
       req = Net::HTTP::Post.new(url.path, initheader = {'Content-Type' => 'application/json'})
       req.body = MultiJson.dump(params)
-      Net::HTTP.start(url.host, url.port, read_timeout: @timeout, use_ssl: true) do |http|
+      Net::HTTP.start(url.host, url.port, read_timeout: @timeout, use_ssl: true, ssl_version: :TLSv1_2) do |http|
         # http://stackoverflow.com/questions/29598196/ruby-net-http-read-body-nethttpokread-body-called-twice-ioerror
         http.request req do |response|
           i = -1


### PR DESCRIPTION
Mailchimp is deprecating support for TLS versions 1.0 and 1.1 in their API.

https://devs.mailchimp.com/blog/tls-1-0-and-1-1-deprecation/

This change enforces the use of TLSv1.2.

Fixes #259 