### PR TITLE
fix typo MAILCHIMP_PROXY in spec

### DIFF
--- a/spec/gibbon/gibbon_spec.rb
+++ b/spec/gibbon/gibbon_spec.rb
@@ -73,7 +73,7 @@ describe Gibbon do
       expect(@gibbon.proxy).to be_nil
     end
 
-    it "sets an proxy url key from the 'MAILCHIMP_PROXY_URL' ENV variable" do
+    it "sets a proxy url key from the 'MAILCHIMP_PROXY' ENV variable" do
       ENV['MAILCHIMP_PROXY'] = @proxy
       @gibbon = Gibbon::Request.new
       expect(@gibbon.proxy).to eq(@proxy)


### PR DESCRIPTION
minor cosmetic change to a test to fix an inconsistent env variable name.