### PR TITLE
Fix incorrect version number in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased][unreleased]
 
-## [3.2.1] - 2019-10-02
+## [3.3.0] - 2019-10-02
 - Fixed compatibility with Faraday 0.16.2+
 - Set minimum Ruby to 2.3.8
 


### PR DESCRIPTION
Seems like you accidentally copied the previous version number in changelog when you probably meant to use v3.3.0 :relaxed: