### PR TITLE
Allow Export API to read API key from environment

### DIFF
--- a/lib/gibbon/export.rb
+++ b/lib/gibbon/export.rb
@@ -7,7 +7,7 @@ module Gibbon
     attr_accessor :api_key, :timeout
 
     def initialize(api_key: nil, timeout: nil)
-      @api_key = api_key || self.class.api_key
+      @api_key = api_key || self.class.api_key || ENV['MAILCHIMP_API_KEY']
       @timeout = timeout || self.class.timeout || 600
     end
 

--- a/spec/gibbon/export_spec.rb
+++ b/spec/gibbon/export_spec.rb
@@ -17,6 +17,13 @@ describe Gibbon::Export do
     expect {@export.list(id: "123456")}.to raise_error(Gibbon::GibbonError)
   end
 
+  it "sets an API key from the 'MAILCHIMP_API_KEY' ENV variable" do
+    ENV['MAILCHIMP_API_KEY'] = 'TESTKEY-us1'
+    @export = Gibbon::Export.new
+    expect(@export.api_key).to eq('TESTKEY-us1')
+    ENV.delete('MAILCHIMP_API_KEY')
+  end
+
   it "sets correct endpoint from api key" do
     @api_key = "TESTKEY-us1"
     @export.api_key = @api_key


### PR DESCRIPTION
This allows `Gibbon::Export` to read an API key from the
`MAILCHIMP_API_KEY` environment variable if it isn't explicitly
specified, making it consistent with `Gibbon::Request`.