### PR TITLE
Update WebMock gem to 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ platforms :rbx do
 end
 
 group :development, :test do
-  gem 'webmock', '~>1.24.0'
+  gem 'webmock', '~> 3.8'
 end
 
 gemspec

--- a/gibbon.gemspec
+++ b/gibbon.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency "rspec", "3.5.0"
-  s.add_development_dependency 'webmock', '~> 1.21.0'
+  s.add_development_dependency 'webmock', '~> 3.8'
 
 end

--- a/spec/gibbon/api_request_spec.rb
+++ b/spec/gibbon/api_request_spec.rb
@@ -6,20 +6,21 @@ describe Gibbon::APIRequest do
 
   before do
     @gibbon = Gibbon::Request.new(api_key: api_key)
-    @api_root = "https://apikey:#{api_key}@us1.api.mailchimp.com/3.0"
+    @api_root = "https://us1.api.mailchimp.com/3.0"
+    @basic_auth_credentials = ['apikey', api_key]
   end
 
   shared_examples_for 'client error handling' do
     it "surfaces client request exceptions as a Gibbon::MailChimpError" do
       exception = error_class.new("the server responded with status 503")
-      stub_request(:get, "#{@api_root}/lists").to_raise(exception)
+      stub_request(:get, "#{@api_root}/lists").with(basic_auth: @basic_auth_credentials).to_raise(exception)
       expect { @gibbon.lists.retrieve }.to raise_error(Gibbon::MailChimpError)
     end
 
     it "surfaces an unparseable client request exception as a Gibbon::MailChimpError" do
       exception = error_class.new(
         "the server responded with status 503")
-      stub_request(:get, "#{@api_root}/lists").to_raise(exception)
+      stub_request(:get, "#{@api_root}/lists").with(basic_auth: @basic_auth_credentials).to_raise(exception)
       expect { @gibbon.lists.retrieve }.to raise_error(Gibbon::MailChimpError)
     end
 
@@ -27,7 +28,7 @@ describe Gibbon::APIRequest do
       response_values = {:status => 503, :headers => {}, :body => '[foo]'}
       exception = error_class.new("the server responded with status 503", response_values)
 
-      stub_request(:get, "#{@api_root}/lists").to_raise(exception)
+      stub_request(:get, "#{@api_root}/lists").with(basic_auth: @basic_auth_credentials).to_raise(exception)
       expect { @gibbon.lists.retrieve }.to raise_error(Gibbon::MailChimpError)
     end
 

--- a/spec/gibbon/upsert_spec.rb
+++ b/spec/gibbon/upsert_spec.rb
@@ -17,8 +17,8 @@ describe Gibbon do
   end
 
   it 'supports upsert request' do
-    stub_request(:put, "https://apikey:1234-us1@us1.api.mailchimp.com/3.0/lists/#{list_id}/members/#{member_id}")
-      .with(body: MultiJson.dump(request_body))
+    stub_request(:put, "https://us1.api.mailchimp.com/3.0/lists/#{list_id}/members/#{member_id}")
+      .with(body: MultiJson.dump(request_body), basic_auth: ['apikey', '1234-us1'])
       .to_return(status: 200)
 
     Gibbon::Request.new(api_key: api_key)


### PR DESCRIPTION
The version of WebMock used has issues with Ruby 2.4+ (although for some
reason this hasn't come up on Travis until now) - c.f.
https://github.com/bblimke/webmock/issues/683

- Bump `webmock` gem to latest version
- Change `stub_request` calls to use new basic auth syntax introduced
  with WebMock 2.0