### PR TITLE
Fix basic auth not working with Faraday.request

### DIFF
--- a/gibbon.gemspec
+++ b/gibbon.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = '>= 2.4.0'
 
-  s.add_dependency('faraday', '>= 0.16.0')
+  s.add_dependency('faraday', '>= 1.0')
   s.add_dependency('multi_json', '>= 1.11.0')
 
   s.add_development_dependency 'rake'

--- a/lib/gibbon/api_request.rb
+++ b/lib/gibbon/api_request.rb
@@ -152,9 +152,9 @@ module Gibbon
         if @request_builder.debug
           faraday.response :logger, @request_builder.logger, bodies: true
         end
-        faraday.request :basic_auth, 'apikey', self.api_key
+        faraday.basic_auth 'apikey', self.api_key
       end
-      
+
       client
     end
 

--- a/lib/gibbon/api_request.rb
+++ b/lib/gibbon/api_request.rb
@@ -152,9 +152,9 @@ module Gibbon
         if @request_builder.debug
           faraday.response :logger, @request_builder.logger, bodies: true
         end
-        faraday.basic_auth 'apikey', self.api_key
+        faraday.request :basic_auth, 'apikey', self.api_key
       end
-
+      
       client
     end
 


### PR DESCRIPTION
```ruby
Faraday.request :basic_auth, "user", "pass"
```
Does not populate request headers with `Authorization: Bearer pass` resulting in 401 Unauthorized response.

Must use instead : 

```ruby
Faraday.basic_auth "user", "pass"
```

Cheers !