### PR TITLE
Support Faraday 2's approach for basic_auth.

### DIFF
--- a/lib/gibbon/api_request.rb
+++ b/lib/gibbon/api_request.rb
@@ -152,9 +152,14 @@ module Gibbon
         if @request_builder.debug
           faraday.response :logger, @request_builder.logger, bodies: true
         end
-        faraday.request :basic_auth, 'apikey', self.api_key
+
+        if Faraday::VERSION.to_i >= 2
+          faraday.request :authorization, :basic, 'apikey', self.api_key
+        else
+          faraday.request :basic_auth, 'apikey', self.api_key
+        end
       end
-      
+
       client
     end
 


### PR DESCRIPTION
This should continue to work with Faraday 1.x as well (the tests were green when I forced the gemspec to use Faraday 1.9).

Faraday's documentation which covers this change:
https://lostisland.github.io/faraday/middleware/authentication