### PR TITLE
Raise if the root domain changed unexepectedly

### DIFF
--- a/lib/gibbon/api_request.rb
+++ b/lib/gibbon/api_request.rb
@@ -194,6 +194,8 @@ module Gibbon
 
     def base_api_url
       computed_api_endpoint = "https://#{get_data_center_from_api_key(self.api_key)}api.mailchimp.com"
+      raise Gibbon::GibbonError, "SSRF attempt" unless URI(computed_api_endpoint).host.include?("api.mailchimp.com")
+
       "#{self.api_endpoint || computed_api_endpoint}/3.0/"
     end
   end

--- a/spec/gibbon/gibbon_spec.rb
+++ b/spec/gibbon/gibbon_spec.rb
@@ -166,7 +166,7 @@ describe Gibbon do
     it "raises with a valid SSRF attack" do
       @api_key = "-attacker.net/test/?"
       @gibbon.api_key = @api_key
-      expect {@gibbon.try.retrieve}.not_to raise_error
+      expect {@gibbon.try.retrieve}.to raise_error(Gibbon::MailChimpError, /SSRF attempt/)
     end
   end
 

--- a/spec/gibbon/gibbon_spec.rb
+++ b/spec/gibbon/gibbon_spec.rb
@@ -162,6 +162,12 @@ describe Gibbon do
       @request = Gibbon::APIRequest.new(builder: @gibbon)
       expect {@request.validate_api_key}.not_to raise_error
     end
+
+    it "raises with a valid SSRF attack" do
+      @api_key = "-attacker.net/test/?"
+      @gibbon.api_key = @api_key
+      expect {@gibbon.try.retrieve}.not_to raise_error
+    end
   end
 
   describe "class variables" do
@@ -213,7 +219,7 @@ describe Gibbon do
     it "set debug on new instances" do
       expect(Gibbon::Request.new.debug).to eq(Gibbon::Request.debug)
     end
-    
+
     it "set faraday_adapter on new instances" do
       expect(Gibbon::Request.new.faraday_adapter).to eq(Gibbon::Request.faraday_adapter)
     end


### PR DESCRIPTION
Due to the concatenation of domains, it's possible to spoof the information into something unexpected, leading essentially to a Server Side Request Forgery.

Instead of validating the api-key format, which could change and could be escaped by playing cat/mouse game around allowed characters/encoding, I've preferred relying on the Ruby parsing of URL post-creation to ensure that the end result is what we expect.

The error itself is not very self-explanatory, happy to change it if you have a better idea :)
Cheers